### PR TITLE
Changes admin-pm input type from single-line text to multi-line message

### DIFF
--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -112,7 +112,7 @@
 
 		//get message text, limit it's length.and clean/escape html
 		if(!msg)
-			msg = input(src,"Message:", "Private message to [key_name(recipient, 0, 0)]") as text|null
+			msg = input(src,"Message:", "Private message to [key_name(recipient, 0, 0)]") as message|null
 			msg = trim(msg)
 			if(!msg)
 				return

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -55,7 +55,7 @@
 
 	if(AH)
 		message_admins("[key_name_admin(src)] has started replying to [key_name(C, 0, 0)]'s admin help.")
-	var/msg = input(src,"Message:", "Private message to [key_name(C, 0, 0)]") as text|null
+	var/msg = input(src,"Message:", "Private message to [key_name(C, 0, 0)]") as message|null
 	if (!msg)
 		message_admins("[key_name_admin(src)] has cancelled their reply to [key_name(C, 0, 0)]'s admin help.")
 		return


### PR DESCRIPTION
:cl:
tweak: changes the admin-pm input box from single line to multi-line
/:cl:

If you're like me and enjoy typing big paragraphs for your bwoinks, you also probably would like to see your entire message for easy re-reading and spell/grammar checking before sending.
The old single line input made doing so pretty difficult, so this should clear up the issue.
