### PR TITLE
Fixes airlock wire regression

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -102,7 +102,7 @@
 
 /obj/machinery/door/airlock/Initialize()
 	. = ..()
-	wires = new /datum/wires/airlock(src)
+	wires = new wiretypepath(src) //CIT CHANGE - makes it possible for airlocks to have different wire datums
 	if(frequency)
 		set_frequency(frequency)
 


### PR DESCRIPTION
This was regressed by the hard sync, as evidenced by github's blame feature https://github.com/Citadel-Station-13/Citadel-Station-13/blame/master/code/game/machinery/doors/airlock.dm#L105

:cl: deathride58
fix: Airlock wires now work as they did prior to the hard sync
/:cl:
