### PR TITLE
Glowshroom spread nerf/bugfix only it compiles

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -96,7 +96,7 @@
 			for(var/turf/open/floor/earth in view(3,src))
 				if(is_type_in_typecache(earth, blacklisted_glowshroom_turfs))
 					continue
-				if(!ownturf.CanAtmosPass(earth))
+				if(!disease_air_spread_walk(ownturf, earth))
 					continue
 				if(spreadsIntoAdjacent || !locate(/obj/structure/glowshroom) in view(1,earth))
 					possibleLocs += earth


### PR DESCRIPTION
disease_air_spread_walk(get_turf(src), earth)
it now respects airblocking objects and won't go through them.