### PR TITLE
Mindshields all roundstart security weapons

### DIFF
--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -97,6 +97,7 @@
 						"The Peacemaker" = "detective_peacemaker"
 						)
 	var/list/safe_calibers
+	pin = /obj/item/firing_pin/implant/mindshield
 
 /obj/item/gun/ballistic/revolver/detective/Initialize()
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -93,6 +93,7 @@
 	unique_reskin = list("Tatical" = "riotshotgun",
 						"Wood Stock" = "wood_riotshotgun"
 						)
+	pin = /obj/item/firing_pin/implant/mindshield
 
 /obj/item/gun/ballistic/shotgun/riot/attackby(obj/item/A, mob/user, params)
 	..()

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -9,6 +9,7 @@
 	ammo_x_offset = 3
 	flight_x_offset = 15
 	flight_y_offset = 10
+	pin = /obj/item/firing_pin/implant/mindshield
 
 /obj/item/gun/energy/e_gun/mini
 	name = "miniature energy gun"
@@ -20,6 +21,7 @@
 	ammo_x_offset = 2
 	charge_sections = 3
 	can_flashlight = 0 // Can't attach or detach the flashlight, and override it's icon update
+	pin = /obj/item/firing_pin
 
 /obj/item/gun/energy/e_gun/mini/Initialize()
 	gun_light = new /obj/item/flashlight/seclite(src)
@@ -36,6 +38,7 @@
 	icon_state = "energytac"
 	ammo_x_offset = 2
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode/spec, /obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser)
+	pin = /obj/item/firing_pin
 
 /obj/item/gun/energy/e_gun/old
 	name = "prototype energy gun"
@@ -43,12 +46,14 @@
 	icon_state = "protolaser"
 	ammo_x_offset = 2
 	ammo_type = list(/obj/item/ammo_casing/energy/laser, /obj/item/ammo_casing/energy/electrode/old)
+	pin = /obj/item/firing_pin
 
 /obj/item/gun/energy/e_gun/mini/practice_phaser
 	name = "practice phaser"
 	desc = "A modified version of the basic phaser gun, this one fires less concentrated energy bolts designed for target practice."
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser/practice)
 	icon_state = "decloner"
+	pin = /obj/item/firing_pin
 
 /obj/item/gun/energy/e_gun/hos
 	name = "\improper X-01 MultiPhase Energy Gun"
@@ -87,6 +92,7 @@
 	can_flashlight = 0
 	trigger_guard = TRIGGER_GUARD_NONE
 	ammo_x_offset = 2
+	pin = /obj/item/firing_pin
 
 /obj/item/gun/energy/e_gun/nuclear
 	name = "advanced energy gun"
@@ -101,6 +107,7 @@
 	selfcharge = EGUN_SELFCHARGE
 	var/fail_tick = 0
 	var/fail_chance = 0
+	pin = /obj/item/firing_pin
 
 /obj/item/gun/energy/e_gun/nuclear/process()
 	if(fail_tick > 0)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -8,6 +8,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun)
 	ammo_x_offset = 1
 	shaded_charge = 1
+	pin = /obj/item/firing_pin/implant/mindshield
 
 /obj/item/gun/energy/laser/practice
 	name = "practice laser gun"
@@ -16,6 +17,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/practice)
 	clumsy_check = 0
 	item_flags = NONE
+	pin = /obj/item/firing_pin
 
 /obj/item/gun/energy/laser/practice/hyperburst
 	name = "toy hyper-burst launcher"
@@ -29,12 +31,14 @@
 	charge_delay = 2
 	recoil = 2
 	cell_type = /obj/item/stock_parts/cell/toymagburst
+	pin = /obj/item/firing_pin
 
 /obj/item/gun/energy/laser/retro
 	name ="retro laser gun"
 	icon_state = "retro"
 	desc = "An older model of the basic lasergun, no longer used by Nanotrasen's private security or military forces. Nevertheless, it is still quite deadly and easy to maintain, making it a favorite amongst pirates and other outlaws."
 	ammo_x_offset = 3
+	pin = /obj/item/firing_pin
 
 /obj/item/gun/energy/laser/retro/old
 	name ="laser gun"
@@ -42,6 +46,7 @@
 	desc = "First generation lasergun, developed by Nanotrasen. Suffers from ammo issues but its unique ability to recharge its ammo without the need of a magazine helps compensate. You really hope someone has developed a better lasergun while you were in cryo."
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun/old)
 	ammo_x_offset = 3
+	pin = /obj/item/firing_pin
 
 /obj/item/gun/energy/laser/captain
 	name = "antique laser gun"
@@ -64,6 +69,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun)
 	cell_type = /obj/item/stock_parts/cell/lascarbine
 	resistance_flags = FIRE_PROOF | ACID_PROOF
+	pin = /obj/item/firing_pin
 
 /obj/item/gun/energy/laser/carbine/nopin
 	pin = null
@@ -74,6 +80,7 @@
 	item_state = "laser"
 	desc = "An industrial-grade heavy-duty laser rifle with a modified laser lens to scatter its shot into multiple smaller lasers. The inner-core can self-charge for theoretically infinite use."
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/scatter, /obj/item/ammo_casing/energy/laser)
+	pin = /obj/item/firing_pin
 
 /obj/item/gun/energy/laser/cyborg
 	can_charge = FALSE
@@ -83,6 +90,7 @@
 	selfcharge = EGUN_SELFCHARGE_BORG
 	cell_type = /obj/item/stock_parts/cell/secborg
 	charge_delay = 3
+	pin = /obj/item/firing_pin
 
 /obj/item/gun/energy/laser/cyborg/emp_act()
 	return
@@ -95,6 +103,7 @@
 	name = "scatter laser gun"
 	desc = "A laser gun equipped with a refraction kit that spreads bolts."
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/scatter, /obj/item/ammo_casing/energy/laser)
+	pin = /obj/item/firing_pin
 
 /obj/item/gun/energy/laser/scatter/shotty
 	name = "energy shotgun"
@@ -105,6 +114,7 @@
 	shaded_charge = 0
 	pin = /obj/item/firing_pin/implant/mindshield
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/scatter/disabler, /obj/item/ammo_casing/energy/electrode)
+	pin = /obj/item/firing_pin
 
 ///Laser Cannon
 
@@ -120,6 +130,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/accelerator)
 	pin = null
 	ammo_x_offset = 3
+	pin = /obj/item/firing_pin
 
 /obj/item/ammo_casing/energy/laser/accelerator
 	projectile_type = /obj/item/projectile/beam/laser/accelerator
@@ -145,6 +156,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/xray)
 	pin = null
 	ammo_x_offset = 3
+	pin = /obj/item/firing_pin
 
 ////////Laser Tag////////////////////
 
@@ -158,6 +170,7 @@
 	pin = /obj/item/firing_pin/tag/blue
 	ammo_x_offset = 2
 	selfcharge = EGUN_SELFCHARGE
+	pin = /obj/item/firing_pin
 
 /obj/item/gun/energy/laser/bluetag/hitscan
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/bluetag/hitscan)
@@ -172,6 +185,7 @@
 	pin = /obj/item/firing_pin/tag/red
 	ammo_x_offset = 2
 	selfcharge = EGUN_SELFCHARGE
+	pin = /obj/item/firing_pin
 
 /obj/item/gun/energy/laser/redtag/hitscan
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/redtag/hitscan)
@@ -194,6 +208,7 @@
 	throw_range = 4
 	throwforce = 10
 	obj_flags = UNIQUE_RENAME
+	pin = /obj/item/firing_pin
 
 /obj/item/gun/energy/laser/redtag/hitscan/chaplain/Initialize()
 	. = ..()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -11,6 +11,7 @@
 	ammo_x_offset = 3
 	flight_x_offset = 17
 	flight_y_offset = 9
+	pin = /obj/item/firing_pin/implant/mindshield
 
 /obj/item/gun/energy/ionrifle/emp_act(severity)
 	return

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -25,6 +25,7 @@
 	// Not enough guns have altfire systems like this yet for this to be a universal framework.
 	var/last_altfire = 0
 	var/altfire_delay = 15
+	pin = /obj/item/firing_pin/implant/mindshield
 
 /obj/item/gun/energy/e_gun/advtaser/altafterattack(atom/target, mob/user, proximity_flag, params)
 	. = TRUE
@@ -46,6 +47,7 @@
 	selfcharge = EGUN_SELFCHARGE_BORG
 	cell_type = /obj/item/stock_parts/cell/secborg
 	charge_delay = 5
+	pin = /obj/item/firing_pin
 
 /obj/item/gun/energy/e_gun/advtaser/cyborg/mean
 	desc = "An integrated hybrid taser that draws directly from a cyborg's power cell."


### PR DESCRIPTION
## About The Pull Request

Title. All roundstart security weapons now have a mindshield firing pin instead of a normal one.

## Why It's Good For The Game

This makes it harder for antags to simply waltz into the armory and walk out gunning everyone, and gives an edge to security. Now you can't just game it when no one's protecting the armory.

## Changelog
:cl:
balance: All roundstart security weapons now have a mindshield firing pin installed.
/:cl:
