### PR TITLE
Proper Bomb Spear Nerf

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -175,10 +175,17 @@
 	name = "Explosive Lance (Grenade)"
 	result = /obj/item/twohanded/spear
 	reqs = list(/obj/item/twohanded/spear = 1,
-				/obj/item/grenade = 1)
+				/obj/item/grenade = 1,
+				/obj/item/restraints/handcuffs/cable = 1,
+				/obj/item/assembly/igniter = 2,
+				/obj/item/stack/sheet/plasteel = 3,
+				/datum/reagent/fuel = 50
+
+				)
 	parts = list(/obj/item/twohanded/spear = 1,
-				/obj/item/grenade = 1)
-	time = 15
+				/obj/item/grenade = 1,
+				/obj/item/restraints/handcuffs/cable = 1)
+	time = 450
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so bomb spears take more time to make (used to be like 10 seconds fucking wew) and require more components (welder fuel, cable restraints, igniters, plasteel).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes a completely bullshit meme weapon less spammable and reasonable.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: changes bombspear components and craft time
balance: nerfs bombspears (kinda)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
