### PR TITLE
Fixes heretic bladeshatters, also fixes find_safe_turf since those were related

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -142,7 +142,8 @@
 		// Can most things breathe?
 		if(trace_gases)
 			continue
-		if(A.get_moles(/datum/gas/oxygen) >= 16)
+		var/oxy_moles = A.get_moles(/datum/gas/oxygen)
+		if(oxy_moles < 16 || oxy_moles > 50)
 			continue
 		if(A.get_moles(/datum/gas/plasma))
 			continue

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -62,13 +62,24 @@
 
 /datum/action/innate/heretic_shatter/IsAvailable()
 	if(IS_HERETIC(holder) || IS_HERETIC_MONSTER(holder))
-		return TRUE
+		return ..()
 	else
 		return FALSE
 
 /datum/action/innate/heretic_shatter/Activate()
 	if(do_after(holder,10, target = holder))
-		var/turf/safe_turf = find_safe_turf(zlevels = sword.z, extended_safety_checks = TRUE)
+		if(!sword || QDELETED(sword))
+			return
+		if(!IsAvailable())	//Never trust the user.
+			return
+		var/swordz = (get_turf(sword))?.z	//SHOULD usually have a turf but if it doesn't better be prepared.
+		if(!swordz)
+			to_chat(holder, "<span class='warning'>[sword] flickers but remains in place, as do you...</span>")
+			return
+		var/turf/safe_turf = find_safe_turf(zlevels = swordz, extended_safety_checks = TRUE)
+		if(!safe_turf)
+			to_chat(holder, "<span class='warning'>[sword] flickers but remains in place, as do you...</span>")
+			return
 		do_teleport(holder,safe_turf,forceMove = TRUE,channel=TELEPORT_CHANNEL_MAGIC)
 		to_chat(holder,"<span class='warning'>You feel a gust of energy flow through your body... the Rusted Hills heard your call...</span>")
 		qdel(sword)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. Bladeshatters did not work and I traced it to find_safe_turf's oxygen check, which was changed to be completely wrong in a previous PR, failing if above 16 moles of oxygen instead of the opposite. This fixes that and makes it so turfs with 16-50 moles of oxygen are accepted (the safe zone of oxygen)

Additionally, while this already fixes the bladeshatter not working at all, this adds a failure message when it fails despite having completed the doafter, aswell as readding the improved check for IsAvailable which was for some reason removed earlier, plus checking after the do_after if it's still available because things do like to change during a second. Oh, and bladeshatters now actually respect which z level you are on instead of always being on the station z, as was intended.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: find_safe_turf no longer always fails on safe oxygen levels(??)
fix: Heretic bladeshatters now actually take the heretic's z into account as intended, instead of always being station z
tweak: Message for failing the bladeshatter despite succeeding the do_after
tweak: Improves bladeshatter a bit by making it safer codewise
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
