### PR TITLE
Fixes demons scattering dropped bodies all over the station, plus space dragon content ejection

### DIFF
--- a/code/modules/antagonists/slaughter/slaughter.dm
+++ b/code/modules/antagonists/slaughter/slaughter.dm
@@ -268,8 +268,6 @@
 	for(var/mob/living/M in consumed_mobs)
 		if(!M)
 			continue	
-		if(!T)
-			T = get_turf(src)
 		M.forceMove(T)
 		if(M.revive(full_heal = TRUE, admin_revive = TRUE))
 			M.grab_ghost(force = TRUE)

--- a/code/modules/antagonists/slaughter/slaughter.dm
+++ b/code/modules/antagonists/slaughter/slaughter.dm
@@ -129,13 +129,12 @@
 /mob/living/simple_animal/slaughter/proc/release_victims()
 	if(!consumed_mobs)
 		return
-
+	var/turf/T = get_turf(src)
+	if(!T)
+		T = find_safe_turf()
 	for(var/mob/living/M in consumed_mobs)
 		if(!M)
 			continue
-		var/turf/T = find_safe_turf()
-		if(!T)
-			T = get_turf(src)
 		M.forceMove(T)
 
 /mob/living/simple_animal/slaughter/proc/refresh_consumed_buff()

--- a/code/modules/antagonists/slaughter/slaughter.dm
+++ b/code/modules/antagonists/slaughter/slaughter.dm
@@ -262,10 +262,12 @@
 	if(!consumed_mobs)
 		return
 
+	var/turf/T = get_turf(src)
+	if(!T)
+		T = find_safe_turf()
 	for(var/mob/living/M in consumed_mobs)
 		if(!M)
-			continue
-		var/turf/T = find_safe_turf()
+			continue	
 		if(!T)
 			T = get_turf(src)
 		M.forceMove(T)

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -123,6 +123,7 @@
 		to_chat(src, "<span class='boldwarning'>You've failed to summon the rift in a timely manner!  You're being pulled back from whence you came!</span>")
 		destroy_rifts()
 		playsound(src, 'sound/magic/demon_dies.ogg', 100, TRUE)
+		empty_contents()
 		QDEL_NULL(src)
 
 /mob/living/simple_animal/hostile/space_dragon/AttackingTarget()

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -637,7 +637,7 @@
 		icon_state = "carp_rift_charged"
 		light_color = LIGHT_COLOR_YELLOW
 		update_light()
-		armor = list(MELEE = 100, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 100, BIO = 100, RAD = 100, FIRE = 100, ACID = 100)
+		armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 100, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100)
 		resistance_flags = INDESTRUCTIBLE
 		dragon.rifts_charged += 1
 		if(dragon.rifts_charged != 3 && !dragon.objective_complete)

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -109,7 +109,7 @@
 			continue
 		playsound(src, 'sound/effects/splat.ogg', 50, TRUE)
 		visible_message("<span class='danger'>[src] vomits up [consumed_mob]!</span>")
-		consumed_mob.forceMove(loc)
+		consumed_mob.forceMove(get_turf(src))
 		consumed_mob.Paralyze(50)
 	if((rifts_charged == 3 || (SSshuttle.emergency.mode == SHUTTLE_DOCKED && rifts_charged > 0)) && !objective_complete)
 		victory()
@@ -351,7 +351,7 @@
   */
 /mob/living/simple_animal/hostile/space_dragon/proc/empty_contents()
 	for(var/atom/movable/AM in src)
-		AM.forceMove(loc)
+		AM.forceMove(get_turf(src))
 		if(prob(90))
 			step(AM, pick(GLOB.alldirs))
 

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -530,7 +530,7 @@
 /obj/structure/carp_rift
 	name = "carp rift"
 	desc = "A rift akin to the ones space carp use to travel long distances."
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 100, BOMB = 50, BIO = 100, RAD = 100, FIRE = 100, ACID = 100)
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 100, "bomb" = 50, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100)
 	max_integrity = 300
 	icon = 'icons/obj/carp_rift.dmi'
 	icon_state = "carp_rift_carpspawn"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
(Disclaimer, I'm unsure if it was intended for them to scatter them across the station and place them on its own tile as failsafe, but the other way round seems more sane)
This fixes (changes?) slaughter and laughter demons to drop bodies on their own tile in case they die, choosing a random safe tile onstation if this is not possible, instead of doing it the opposite way around.
Additionally, even if this failsafe triggers, all bodies will end up on the same tile.
~~Also makes space dragons slightly safer when ejecting their victims because I don't trust going directly via loc, though from local testing it required no direct fixes.~~
fixes #15036 
Edit:
Thanks to some insight on the nature of the issue, I was able to locate and fix it. Minor tweaks still in though.
Now fixes dragons deleting their victims if they run out of time too.

Edit2:
Also now fixes carp rift armor to not runtime.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Demons now drop bodies on their own tile instead of scattering them across the station.
tweak: Space dragon content ejection is now slightly safer.
fix: Space dragons no longer delete their contents if they die due to timeout, ejecting them instead.
fix: Carp rifts created by space dragons now have their armor work correctly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
