### PR TITLE
Reverts an undocumented change to pirate payoff minimum cost from the dynamic PR

### DIFF
--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -24,7 +24,7 @@
 	var/pirate_type = PIRATES_ROGUES //pick(PIRATES_ROGUES, PIRATES_SILVERSCALES, PIRATES_DUTCHMAN)
 	var/datum/comm_message/threat_msg = new
 	var/payoff = 0
-	var/payoff_min = 10000
+	var/payoff_min = 1000
 	var/ship_template
 	var/ship_name = "Space Privateers Association"
 	var/initial_send_time = world.time


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The dynamic PR had a change modifying pirate minimum payoff to 10k instead of 1k, which is a value that is primarily only relevant when cargo is not manned (even 15000 in cargo's budget would be over 10k with the default calculation)
As cargo is not always manned and the popcap of this event is comperatively low (10 legacy modes, 18 dynamic), both Silicons and I agreed this change would not have passed if PRd seperately.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Undocumented changes that have no maintainer okay bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Reverts an undocumented change to pirate minimum payoff (10k back to 1k)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
