### PR TITLE
Allows setting vents to siphon

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -403,6 +403,9 @@
 		if("incheck")
 			send_signal(device_id, list("checks" = text2num(params["val"])^2), usr)
 			. = TRUE
+		if("direction")
+			send_signal(device_id, list("direction" = text2num(params["val"])), usr)
+			. = TRUE
 		if("set_external_pressure", "set_internal_pressure")
 
 			var/target = params["value"]

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -144,7 +144,7 @@
 		"device" = "VP",
 		"timestamp" = world.time,
 		"power" = on,
-		"direction" = pump_direction ? "release" : "siphon",
+		"direction" = pump_direction,
 		"checks" = pressure_checks,
 		"internal" = internal_pressure_bound,
 		"external" = external_pressure_bound,

--- a/tgui/packages/tgui/interfaces/common/AtmosControls.js
+++ b/tgui/packages/tgui/interfaces/common/AtmosControls.js
@@ -37,7 +37,7 @@ export const Vent = (props, context) => {
         <LabeledList.Item label="Mode">
           <Button
             icon="sign-in-alt"
-            content={direction ? 'Pressurizing' : 'Scrubbing'}
+            content={direction ? 'Pressurizing' : 'Siphoning'}
             color={!direction && 'danger'}
             onClick={() => act('direction', {
               id_tag,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I was going to add this as a big feature thing but the more I looked at the code the more it looked like an *oversight* rather than a new feature that needed to be added in. So, here's the code required to fix it, plus a *bug fix*, plus a single irrelevant terminology change. It's 3 lines. 

## Why It's Good For The Game

Giving atmos more toys won't actually help them kill everyone easier, believe it or not. They can do that pretty easily regardless!

Remains to be seen, though.

EDIT: These things are actually really well-balanced and I suspect them not being usable was an oversight rather than a balance concern. Good lord.

## Changelog
:cl:
add: Vent pumps can now be set to siphoning via the air alarm UI
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
