### PR TITLE
Properly implements hysteresis on heat exchanger processing

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/heat_exchanger.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/heat_exchanger.dm
@@ -12,6 +12,8 @@
 
 	var/obj/machinery/atmospherics/components/unary/heat_exchanger/partner = null
 	var/update_cycle
+	var/old_temperature = 0
+	var/other_old_temperature = 0
 
 	pipe_state = "heunary"
 
@@ -59,9 +61,6 @@
 	var/other_air_heat_capacity = partner_air_contents.heat_capacity()
 	var/combined_heat_capacity = other_air_heat_capacity + air_heat_capacity
 
-	var/old_temperature = air_contents.return_temperature()
-	var/other_old_temperature = partner_air_contents.return_temperature()
-
 	if(combined_heat_capacity > 0)
 		var/combined_energy = partner_air_contents.return_temperature()*other_air_heat_capacity + air_heat_capacity*air_contents.return_temperature()
 
@@ -71,6 +70,8 @@
 
 	if(abs(old_temperature-air_contents.return_temperature()) > 1)
 		update_parents()
+		old_temperature = air_contents.return_temperature()
 
 	if(abs(other_old_temperature-partner_air_contents.return_temperature()) > 1)
 		partner.update_parents()
+		other_old_temperature = partner_air_contents.return_temperature()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Before: heat exchangers only update their parent if they change by a full kelvin *in one tick*.

After: heat exchangers update their parent whenever they change by a full kelvin *at all*.

## Why It's Good For The Game

The previous behavior was dumb.

## Changelog
:cl:
fix: Properly implemented hysteresis on heat exchanger processing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
