### PR TITLE
Bone glaive sprites didn't show up properly...

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -235,6 +235,9 @@
 	icon_state = "crusher-bone"
 	item_state = "crusher0-bone"
 
+/obj/item/kinetic_crusher/glaive/bone/update_icon_state()
+	item_state = "crusher[wielded]-bone"
+
 //destablizing force
 /obj/item/projectile/destabilizer
 	name = "destabilizing force"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I was surprised to see that the wielded sprites on the recently greenlit bone glaive didn't show up.
Turns out I either missed something in the code or the code was changed in the three months it took to get my PR merged. Maybe both. I dunno. So here's a small change so the glaive looks unique when you hold it too.<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

If I make extra sprites, you can expect I'd want them to show up in-game too.<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed the wielded sprites not showing up properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
