### PR TITLE
tesla counterplay now accounts for grounding rod capacitor type

### DIFF
--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -364,8 +364,8 @@
 				// assuming the rod is fully constructed the second part will always be a capacitor
 				var/obj/item/stock_parts/capacitor/capacitor = rod.component_parts[2]
 
-				qdel(closest_atom) // each rod removes tesla energy depending on the power of the capacitor,
 				tesla.energy = round(tesla.energy/(1 + 0.28125 * capacitor.rating))
+				qdel(closest_atom) // each rod removes tesla energy depending on the power of the capacitor,
 				// if there are no miniballs the rod stays and continues to pull the ball in
 
 	if(prob(20))//I know I know

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -358,8 +358,16 @@
 		var/obj/singularity/energy_ball/tesla = source
 		if(istype(tesla))
 			if(istype(closest_atom,/obj/machinery/power/grounding_rod) && tesla.energy>13 && !tesla.contained)
-				qdel(closest_atom)							// each rod deletes two miniballs,
-				tesla.energy = round(tesla.energy/1.5625)	// if there are no miniballs the rod stays and continues to pull the ball in
+
+				// getting the grounding rod's capacitor rating for quick maths
+				var/obj/machinery/power/grounding_rod/rod = closest_atom
+				// assuming the rod is fully constructed the second part will always be a capacitor
+				var/obj/item/stock_parts/capacitor/capacitor = rod.component_parts[2]
+
+				qdel(closest_atom) // each rod removes tesla energy depending on the power of the capacitor,
+				tesla.energy = round(tesla.energy/(1 + 0.28125 * capacitor.rating))
+				// if there are no miniballs the rod stays and continues to pull the ball in
+
 	if(prob(20))//I know I know
 		tesla_zap(closest_atom, next_range, power * 0.5, zap_flags, shocked_targets)
 		tesla_zap(closest_atom, next_range, power * 0.5, zap_flags, shocked_targets)


### PR DESCRIPTION
## About The Pull Request
likely needs more balancing but the basic framework for it is there now.

## Why It's Good For The Game
it didn't before, now it does.

## Changelog
:cl:
tweak: uncontained tesla grounding rod zap energy loss accounts for rod capacitor rating
/:cl: