### PR TITLE
Adds a hotkey for the *surrender emote and makes it more potent.

### DIFF
--- a/code/modules/keybindings/keybind/human.dm
+++ b/code/modules/keybindings/keybind/human.dm
@@ -26,3 +26,15 @@
 	var/mob/living/carbon/human/H = user.mob
 	H.smart_equipbag()
 	return TRUE
+
+/datum/keybinding/human/surrender
+	hotkey_keys = list("AltShiftY")
+	name = "surrender"
+	full_name = "Surrender"
+	category = CATEGORY_COMBAT
+	description = "Briefly stuns and incapacitates you to show you're no longer a threat."
+
+/datum/keybinding/human/surrender/down(client/user)
+	. = ..()
+	var/mob/living/carbon/human/H = user.mob
+	return H.emote("surrender", intentional=TRUE)

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -389,14 +389,15 @@
 /datum/emote/living/surrender
 	key = "surrender"
 	key_third_person = "surrenders"
-	message = "puts their hands on their head and falls to the ground, they surrender!"
-	emote_type = EMOTE_AUDIBLE
+	message = "surrenders!"
 
 /datum/emote/living/surrender/run_emote(mob/user, params)
 	. = ..()
-	if(. && isliving(user))
-		var/mob/living/L = user
-		L.DefaultCombatKnockdown(200)
+	if(. && ishuman(user))
+		var/mob/living/carbon/human/H = user
+		H.DefaultCombatKnockdown(amount = 800, ignore_canknockdown = TRUE)
+		H.UseStaminaBuffer(amount = H.stamina_buffer)
+		ENABLE_BITFIELD(H.combat_flags, COMBAT_FLAG_INTENTIONALLY_RESTING)
 
 /datum/emote/living/sway
 	key = "sway"

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -320,3 +320,4 @@ EMPs can be created by mixing uranium and iron. The power of the pulse is determ
 Some lizardpeople start with an unactivated mutation that allows them to breath fire. This can be unlocked through the usage of genetics!
 Some loadout items can be unlocked through progress in parts of the game. The progress for these can be tracked in the loadout menu.
 It's easy to forget that everyone else you're playing with is a real person trying to have as much fun as you are. Be nice to your fellow spacemen.
+Want to surrender and avoid a fight? Alt+Shift+Y is the default hotkey for the *surrender emote, but be sure before you use it - you'll be helpless for a bit after you do!


### PR DESCRIPTION
## About The Pull Request

Adds a hotkey for the *surrender emote - by default Alt-Shift-Y.
Makes surrendering floor you, drain basically all stamina, and set lying so you don't automatically get back up before you intend to. 

## Why It's Good For The Game

Sometimes people want to give up/get out of a fight before they get destroyed. 

_While this is no guarantee that they won't be_, the ability to self-stun with the visual indicator of your sprite getting darker (stamcrit) is a quick tool to signal you're throwing in the towel. Will hopefully clear up some of the salt-inducing edge cases of people getting fragged because it couldn't be said whether or not they were a threat. Typing out the whole emote was impractically slow as quick as things happen here. 

## Changelog
:cl:
add: A new default hotkey for *surrender - Alt+Shift+Y. You can rebind this under the Combat keybindings if it's too close to other hotkeys. 
balance: Surrendering now effectively drains your stamina to nothing, floors you, and temporarily hard-stuns you with a visual indicator. It takes a little better than ten seconds on average to start getting back up if you haven't been in combat. You'll have to manually start getting back up (V by default) even if you have auto-stand enabled in preferences. 
/:cl:
