### PR TITLE
Makes bodies laying on the ground also act as obstacles to crawling.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -116,19 +116,19 @@
 						to_chat(src, "<span class='warning'>[L] is restraining [P], you cannot push past.</span>")
 					return 1
 
-	//CIT CHANGES START HERE - makes it so resting stops you from moving through standing folks without a short delay
-		if(!CHECK_MOBILITY(src, MOBILITY_STAND) && CHECK_MOBILITY(L, MOBILITY_STAND))
+	//CIT CHANGES START HERE - makes it so resting stops you from moving through standing folks or over prone bodies without a short delay
+		if(!CHECK_MOBILITY(src, MOBILITY_STAND))
 			var/origtargetloc = L.loc
 			if(!pulledby)
 				if(combat_flags & COMBAT_FLAG_ATTEMPTING_CRAWL)
 					return TRUE
 				if(IS_STAMCRIT(src))
-					to_chat(src, "<span class='warning'>You're too exhausted to crawl under [L].</span>")
+					to_chat(src, "<span class='warning'>You're too exhausted to crawl [(CHECK_MOBILITY(L, MOBILITY_STAND)) ? "under": "over"] [L].</span>")
 					return TRUE
 				ENABLE_BITFIELD(combat_flags, COMBAT_FLAG_ATTEMPTING_CRAWL)
-				visible_message("<span class='notice'>[src] is attempting to crawl under [L].</span>",
-					"<span class='notice'>You are now attempting to crawl under [L].</span>",
-					target = L, target_message = "<span class='notice'>[src] is attempting to crawl under you.</span>")
+				visible_message("<span class='notice'>[src] is attempting to crawl [(CHECK_MOBILITY(L, MOBILITY_STAND)) ? "under" : "over"] [L].</span>",
+					"<span class='notice'>You are now attempting to crawl [(CHECK_MOBILITY(L, MOBILITY_STAND)) ? "under": "over"] [L].</span>",
+					target = L, target_message = "<span class='notice'>[src] is attempting to crawl [(CHECK_MOBILITY(L, MOBILITY_STAND)) ? "under" : "over"] you.</span>")
 				if(!do_after(src, CRAWLUNDER_DELAY, target = src) || CHECK_MOBILITY(src, MOBILITY_STAND))
 					DISABLE_BITFIELD(combat_flags, COMBAT_FLAG_ATTEMPTING_CRAWL)
 					return TRUE

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -37,6 +37,8 @@
 		if(mover in buckled_mobs)
 			return TRUE
 	var/mob/living/L = mover		//typecast first, check isliving and only check this if living using short circuit
+	if(lying && L.lying)		//if we're both lying down and aren't already being thrown/shipped around, don't pass
+		return FALSE
 	return (!density || (isliving(mover)? L.can_move_under_living(src) : !mover.density))
 
 /mob/living/toggle_move_intent()


### PR DESCRIPTION
## About The Pull Request

Applies the same do_after that crawling under standing people gets to crawling over prone people/bodies. 

## Why It's Good For The Game

The sprite-jumbling scramble that goes on when people are crawling around under each other in the middle of a ground-fight isn't good. It's bad, even. This is a bit more of a reason to want to get back on your feet in a fight because your options suddenly become a lot more limited if you're on the ground in a crowd with other people who've gone down. 

## Changelog
:cl:
tweak: Applies the same delay from crawling under standing people to crawling over prone people.
/:cl:
