### PR TITLE
Fixes DSword and Hyper Eu's wounding, and fixes a slowdown bug with Hyper Eu.

### DIFF
--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -23,7 +23,7 @@
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 70)
 	resistance_flags = FIRE_PROOF
-	wound_bonus = -110
+	wound_bonus = -40
 	bare_wound_bonus = 20
 	block_parry_data = /datum/block_parry_data/dual_esword
 	block_chance = 60
@@ -133,7 +133,7 @@
 	total_mass = initial(total_mass)
 	wielded = FALSE
 	hitsound = "swing_hit"
-	slowdown_wielded -= slowdown_wielded
+	slowdown -= slowdown_wielded
 	STOP_PROCESSING(SSobj, src)
 	set_light(0)
 	RemoveElement(/datum/element/sword_point)
@@ -278,6 +278,7 @@
 	desc = "A supermassive weapon envisioned to cleave the very fabric of space and time itself in twain, the hypereutactic blade dynamically flash-forges a hypereutactic crystaline nanostructure capable of passing through most known forms of matter like a hot knife through butter."
 	force = 7
 	hitsound_on = 'sound/weapons/nebhit.ogg'
+	wound_bonus = -20
 	armour_penetration = 60
 	light_color = "#37FFF7"
 	rainbow_colors = list("#FF0000", "#FFFF00", "#00FF00", "#00FFFF", "#0000FF","#FF00FF", "#3399ff", "#ff9900", "#fb008b", "#9800ff", "#00ffa3", "#ccff00")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Puts DSwords wound bonus from -110 (what the fuck) to -40.

Puts Hyper Eu's wound bonus from -110 to -20.

Also fixes the slowdown issue when Hyper Eu was off.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The bugfix for the slowdown is good for an obvious bug fix.

The wounds, this is a bit ridiculous.  I get it more for the DSword, which is why I put it at -40.  But for the hyper eu, it means you can't wound until they're dead.  You're already super slow when wielding it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: -40 wound bonus for DSword
balance: -20 Wound bonus for Hyper Eu
fix: Fixes hyper eu's slowdown when it's not wielded 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
