### PR TITLE
fixes blood trails looking Wonky by removing their base iconstate

### DIFF
--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -82,7 +82,6 @@
 /obj/effect/decal/cleanable/trail_holder //not a child of blood on purpose
 	name = "blood"
 	icon = 'icons/effects/blood.dmi'
-	icon_state = "ltrails_1"
 	desc = "Your instincts say you shouldn't be following these."
 	random_icon_states = null
 	beauty = -50


### PR DESCRIPTION

## About The Pull Request
Title! This is a fairly straight-forward one-line fix.


## Changelog
:cl: Bhijn & Myr
fix: Blood trails no longer have a duplicate directionless iconstate as their base sprite, fixing the Wonkiness of blood trails going west/east.
/:cl:
